### PR TITLE
Added base name to base time example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@ To shorten documents and improve readability, an optional base time may be given
         { "n": "temperature", "u": "Cel", "t": 0, "v":22.5 },
         { "n": "light", "u": "lm", "t": 1, "v":135 }
       ],
+      "bn": "http://example.org/sensor1/",
       "bt": 1234
     }
 


### PR DESCRIPTION
The base time example provides two 'equivalent' example files, however the second of the two is missing base name prefixes. It looks like a base name element should therefore be included to ensure the two really are equivalent.
